### PR TITLE
Fix issue with habanero’s PseudoRandom which does not generate uniform random numbers by using java.util.Random instead (In Facility Location benchmark)

### DIFF
--- a/src/main/java/edu/rice/habanero/benchmarks/facloc/FacilityLocationConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/facloc/FacilityLocationConfig.java
@@ -21,6 +21,8 @@ public final class FacilityLocationConfig {
     protected static int C = 1;
     protected static boolean debug = false;
 
+    private static Random r = new Random();
+
     protected static void parseArgs(final String[] args) {
         int i = 0;
         while (i < args.length) {
@@ -58,12 +60,11 @@ public final class FacilityLocationConfig {
         System.out.printf(BenchmarkRunner.argOutputFormat, "debug", debug);
     }
 
+
     protected static class Point {
 
-        private static PseudoRandom r = new PseudoRandom();
-
         protected static void setSeed(final long seed) {
-            r = new PseudoRandom(seed);
+            r = new Random(seed);
         }
 
         protected static Point random(final double gridSize) {

--- a/src/main/java/edu/rice/habanero/benchmarks/facloc/FacilityLocationConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/facloc/FacilityLocationConfig.java
@@ -1,7 +1,6 @@
 package edu.rice.habanero.benchmarks.facloc;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
-import edu.rice.habanero.benchmarks.PseudoRandom;
 
 import java.util.*;
 


### PR DESCRIPTION
Fix issue with habanero’s PseudoRandom which does not generate uniform random numbers by using java.util.Random instead (In Facility Location benchmark)

- Although the points are supposed to be uniformly distributed between (0,0) and (500, 500) when the grid size is 500, the actual points created using habanero’s PseudoRandom are focused around (0,0), like (0.01, 0.02), (0.02, 0.01), etc.
- This makes the benchmark create only a very small number of facilities in the end (around 14 even when the NUM_POINTS (number of customers) is 100,000), as the customer cost is calculated based on the random position of customers and all the customers are positioned around (0, 0), which leads to overall very small customer cost.
- Normally when NUM_POINTS is 100,000, the number of facilities, in the end, should be around 341.